### PR TITLE
Fix performance issue with regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,13 +8,6 @@
 'use strict'
 
 /**
- * RegExp to check for no-cache token in Cache-Control.
- * @private
- */
-
-var CACHE_CONTROL_NO_CACHE_REGEXP = /(?:^|,)\s*?no-cache\s*?(?:,|$)/
-
-/**
  * Module exports.
  * @public
  */
@@ -44,7 +37,7 @@ function fresh (reqHeaders, resHeaders) {
   // to support end-to-end reload requests
   // https://tools.ietf.org/html/rfc2616#section-14.9.4
   var cacheControl = reqHeaders['cache-control']
-  if (cacheControl && CACHE_CONTROL_NO_CACHE_REGEXP.test(cacheControl)) {
+  if (cacheControl && cacheControl.indexOf("no-cache") > -1) {
     return false
   }
 


### PR DESCRIPTION
Replacing the no-cache regex with indexOf makes a significant performance difference. And works the same way.

See: https://jsperf.com/test-regexck

I found this profiling my expressjs application where this regex was the no1 performance eater.